### PR TITLE
Fix/line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ $ dos2unix run.pbs
 
 Changes
 -------
+Changed in version 1.5.2
+  * increased WORK_STR_LENGTH from 4 kb to 1 Mb
+
 New in version 1.5.1
   * PBS scripts can use `WORKER_RANK` and `WORKER_SIZE` for process binding
   

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([worker], [1.5.1], [geertjan.bex@uhasselt.be])
+AC_INIT([worker], [1.5.2], [geertjan.bex@uhasselt.be])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign tar-pax])
 AC_PROG_CC([mpiicc])
 AC_CHECK_HEADERS([stdlib.h])

--- a/src/worker.h
+++ b/src/worker.h
@@ -21,7 +21,7 @@ typedef struct {
 extern MPI_Datatype jobInfoType, jobExitInfoType;
 
 /* initial length of the char array that will hold a batch script */
-#define WORK_STR_LENGTH 4096
+#define WORK_STR_LENGTH 1048576
 
 /* interpreter to use by the slaves for the batch scripts */
 #define BASH "/bin/bash -l"


### PR DESCRIPTION
Increased WORK_STR_LENGTH to accommodate a use case with a very large number of parameters.  The length is now 1 Mb, rather than 4 kb.  This is acceptable since this is the length of a buffer that is only instantiated by the master process.