### PR TITLE
Documentation fix

### DIFF
--- a/conf/worker.conf
+++ b/conf/worker.conf
@@ -55,7 +55,7 @@
 
 # MPI related configuration
   unload_modules = intel
-  mpi_module = intel/2014a
+  mpi_module = intel/2015a
   mpirun = mpirun
   mpirun_options = -np ${n_proc}
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,3 +1,8 @@
+Changed in version 1.6.1
+
+  * bug fix for incorrectly handled absolute paths of prologue/epilogue
+    files
+
 New in version 1.6.0
 
   * `wreduce`: a more generic result aggregation function where one can

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: worker is intended to easily submit and manage embarrasignly p
 site_author: Geert Jan Bex
 pages:
 - Introduction and motivation: 'index.md'
-- Step by step: 'index.md'
+- Step by step: 'steps.md'
 - Prologue and epilogue: 'mapreduce.md'
 - Monitoring worker jobs: 'monitoring.md'
 - Limiting execution time: 'time_limits.md'


### PR DESCRIPTION
The YAML file describing the documentation content was incorrect, resulting in a section that was missing.
Switch to intel/2015a toolchain in worker.conf file.