### PR TITLE
Do not append -C with PBS default

### DIFF
--- a/src/perl/Pbs/Parser.pm
+++ b/src/perl/Pbs/Parser.pm
@@ -8,13 +8,17 @@ use warnings;
 
 use Pbs::Description;
 
+use Readonly;
+
+Readonly our $DEFAULT_PREFIX => '#PBS';
+
 # ----------------------------------------------------------------------------
 # constructor, takes a PBS file as an argument, and optionally, a PBS
 # directive prefix (defaults to '#PBS'
 # ----------------------------------------------------------------------------
 sub new {
     my $pkg = shift(@_);
-    my $self = bless {prefix  => '#PBS'}, $pkg;
+    my $self = bless {prefix  => $DEFAULT_PREFIX}, $pkg;
     return $self;
 }
 

--- a/src/perl/wsub
+++ b/src/perl/wsub
@@ -344,7 +344,7 @@ if (defined $job_name) {
     unshift(@ARGV, '-N', $job_name);
 }
 # -C
-if (defined $directive_prefix) {
+if (defined $directive_prefix && $directive_prefix ne $Pbs::Parser::DEFAULT_PREFIX) {
     unshift(@ARGV, '-C', $directive_prefix);
 }
 # -t: do not put this back, this is for PBS array requests, and is


### PR DESCRIPTION
it seems that `qsub` does not properly pass the commandline arguments to the submitfilter, in particular the `#` from the prefix is troublesome.
this is a workaround to let the submitfilter do its work when using default prefix (while a fix for `qsub` is not available).
