### PR TITLE
fix compatibility with OpenMPI 4.x by replacing deprecated MPI_Type_struct with MPI_Type_create_struct

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -116,9 +116,9 @@ void initMpiTypes(void) {
     offsets[0] = 0;
     baseTypes[0] = MPI_INT;
     blockCounts[0] = 2;
-    MPI_Type_struct(1, blockCounts, offsets, baseTypes, &jobInfoType);
+    MPI_Type_create_struct(1, blockCounts, offsets, baseTypes, &jobInfoType);
     MPI_Type_commit(&jobInfoType);
-    MPI_Type_struct(1, blockCounts, offsets, baseTypes, &jobExitInfoType);
+    MPI_Type_create_struct(1, blockCounts, offsets, baseTypes, &jobExitInfoType);
     MPI_Type_commit(&jobExitInfoType);
 }
 


### PR DESCRIPTION
Fix for compilation error that pops up when using OpenMPI 4.x:

```
mpicc -DPACKAGE_NAME=\"worker\" -DPACKAGE_TARNAME=\"worker\" -DPACKAGE_VERSION=\"1.6.10\" -DPACKAGE_STRING=\"worker\ 1.6.10\" -DPACKAGE_BUGREPORT=\"geertjan.bex@uhasselt.be\" -DPACKAGE_URL=\"\" -DPACKAGE=\"worker\" -DVERSION=\"1.6.10\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_UNISTD_H=1 -I.   -I/software/FFTW/3.3.8-gompi-2020a/include -I/software/ScaLAPACK/2.1.0-gompi-2020a/include -I/software/OpenBLAS/0.3.9-GCC-9.3.0/include  -O2 -ftree-vectorize -march=native -fno-math-errno -MT worker.o -MD -MP -MF .deps/worker.Tpo -c -o worker.o worker.c
In file included from worker.c:13:
worker.c: In function initMpiTypes:
/software/OpenMPI/4.0.3-GCC-9.3.0/include/mpi.h:322:57: error: static assertion failed: "MPI_Type_struct was removed in MPI-3.0.  Use MPI_Type_create_struct instead."
  322 | #define THIS_SYMBOL_WAS_REMOVED_IN_MPI30(func, newfunc) _Static_assert(0, #func " was removed in MPI-3.0.  Use " #newfunc " instead.")
      |                                                         ^~~~~~~~~~~~~~
/software/OpenMPI/4.0.3-GCC-9.3.0/include/mpi.h:2850:31: note: in expansion of macro THIS_SYMBOL_WAS_REMOVED_IN_MPI30
 2850 | #define MPI_Type_struct(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_struct, MPI_Type_create_struct)
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
worker.c:119:5: note: in expansion of macro MPI_Type_struct
  119 |     MPI_Type_struct(1, blockCounts, offsets, baseTypes, &jobInfoType);
      |     ^~~~~~~~~~~~~~~
/software/OpenMPI/4.0.3-GCC-9.3.0/include/mpi.h:322:57: error: static assertion failed: "MPI_Type_struct was removed in MPI-3.0.  Use MPI_Type_create_struct instead."
  322 | #define THIS_SYMBOL_WAS_REMOVED_IN_MPI30(func, newfunc) _Static_assert(0, #func " was removed in MPI-3.0.  Use " #newfunc " instead.")
      |                                                         ^~~~~~~~~~~~~~
/software/OpenMPI/4.0.3-GCC-9.3.0/include/mpi.h:2850:31: note: in expansion of macro THIS_SYMBOL_WAS_REMOVED_IN_MPI30
 2850 | #define MPI_Type_struct(...)  THIS_SYMBOL_WAS_REMOVED_IN_MPI30(MPI_Type_struct, MPI_Type_create_struct)
      |                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
worker.c:121:5: note: in expansion of macro MPI_Type_struct
  121 |     MPI_Type_struct(1, blockCounts, offsets, baseTypes, &jobExitInfoType);
      |     ^~~~~~~~~~~~~~~
make[2]: *** [worker.o] Error 1
```

As far as I can tell, `MPI_Type_create_struct` is a drop-in replacement for `MPI_Type_struct`; see for example https://www.rookiehpc.com/mpi/docs/mpi_type_create_struct.php